### PR TITLE
Fix violin plot

### DIFF
--- a/R/SurveyFit.R
+++ b/R/SurveyFit.R
@@ -154,7 +154,7 @@ SurveyFit <- R6::R6Class(
     #' @param weights TRUE (default) if weighted estimates are included for comparison. Weighted interval is a 95% interval.
     #'  If no weights are specified, weights are assumed to be 1, which is roughly equivalent to the observed data average.
     plot = function(aggregated_estimates, weights = TRUE) {
-      if (ncol(aggregated_estimates) > 2) {
+      if (ncol(aggregated_estimates) > 1) {
         focus_var <- colnames(aggregated_estimates)[1]
         which_q <- private$map_$item_map()[[focus_var]]$col_names()[1]
         svy_q <- private$map_$sample()$questions()[[which_q]]
@@ -178,7 +178,7 @@ SurveyFit <- R6::R6Class(
       if (weights) {
         model_fit <- private$fit_
         lhs_var <- as.character(formula(model_fit))[[2]]
-        if (ncol(aggregated_estimates) > 2) {
+        if (ncol(aggregated_estimates) > 1) {
           by_var <- colnames(aggregated_estimates)[1]
           wtd_ests <- create_wtd_ests(self, lhs_var, by=by_var)
           gg <- gg +

--- a/tests/testthat/test-SurveyFit.R
+++ b/tests/testthat/test-SurveyFit.R
@@ -226,7 +226,6 @@ test_that("plot appearance hasn't changed", {
   # need to use deterministic inputs to the plots to test appearance changes
   popn <- data.frame(value = c(0.60, 0.65, 0.70, 0.75, 0.80))
   by_age <- data.frame(age = factor(rep(1:4, 5), labels = levels(ex_map$mapped_sample_data()$age)),
-                       draw = rep(1:5, each = 4),
                        value = c(0.299514804640785, 0.217973976861686, 0.258871184848249, 0.271914651058614,
                                  0.31649006572552, 0.697755558183417, 0.209188556019217, 0.431414544349536,
                                  0.74861360588111, 0.209171398542821, 0.385790600813925, 0.45710161360912,


### PR DESCRIPTION
Closes #120 

* Doesn't assume `draw` column is present when detecting number of columns to decide which plot to make
* Removes `draw` column from fake data used in test (this was preventing the test from failing when it should have failed) 