### PR TITLE
fixes to allow custom functions

### DIFF
--- a/R/SurveyFit.R
+++ b/R/SurveyFit.R
@@ -181,7 +181,7 @@ SurveyFit <- R6::R6Class(
           dplyr::mutate(method = "mrp")
 
           lhs_binary <- self$map()$sample()$survey_data() %>%
-          dplyr::select(lhs_var, .key)%>%
+          dplyr::select(dplyr::all_of(lhs_var), .key)%>%
           dplyr::mutate(lhs_binary = force_factor(.data[[lhs_var]]))
 
         raw_data <- self$map()$mapped_sample_data() %>%

--- a/R/SurveyFit.R
+++ b/R/SurveyFit.R
@@ -116,7 +116,7 @@ SurveyFit <- R6::R6Class(
         }
       } else {
         fun <- match.fun(fun)
-        fun(fitted_model, poststrat, ...)
+        fun(private$fit_, poststrat, ...)
       }
     },
 

--- a/R/SurveyMap.R
+++ b/R/SurveyMap.R
@@ -544,7 +544,8 @@ SurveyMap <- R6::R6Class(
                 call. = FALSE
         )
       }
-      if (!any(getNamespaceName(environment(fun)) %in% c("lme4","brms","rstanarm"))) {
+      if (isNamespace(environment(fun))
+          && !any(getNamespaceName(environment(fun)) %in% c("lme4","brms","rstanarm"))) {
         warning("Only rstanarm, brms and lme4 are supported natively. ",
                 "Other modeling tools will need a custom population_predict() method.",
                 call. = FALSE)

--- a/tests/testthat/test-SurveyFit.R
+++ b/tests/testthat/test-SurveyFit.R
@@ -470,3 +470,26 @@ test_that("force factor works appropriately",{
   x <- c(1,1, NA)
   expect_equal(force_factor(x), c(1,1, NA))
 })
+
+
+test_that("custom prediction function works", {
+  myfit <- function(data, formula, ...) {
+    rstanarm::stan_glm(formula = formula, data = data, ...)
+  }
+  mypred <- function(mod, ps, ...) {
+    t(suppressMessages(rstanarm::posterior_linpred(
+      mod,
+      newdata = ps,
+      transform = TRUE
+    )))
+  }
+  fit1 <- ex_map$fit(
+    fun = myfit,
+    formula = y ~ age + gender,
+    family = "binomial",
+    iter = 1000,
+    refresh = 0
+  )
+  p <- fit1$population_predict(fun = mypred)
+  expect_equal(dim(p), c(nrow(ex_map$poststrat_data()), 2000))
+})


### PR DESCRIPTION
This PR avoids an error when using a custom modeling function. We are still limited by #105 (requiring formula argument), but at least now it should work for some custom functions. I also added a test to make sure there are no errors when fitting or doing prediction. 