### PR TITLE
don't allow 'weights' argument to SurveyMap$fit()

### DIFF
--- a/R/SurveyMap.R
+++ b/R/SurveyMap.R
@@ -544,6 +544,10 @@ SurveyMap <- R6::R6Class(
         stop("The 'data' argument should not be specified.",
              call. = FALSE)
       }
+      if (!is.null(args$weights)) {
+        stop("The 'weights' argument is not allowed when fitting models.",
+             call. = FALSE)
+      }
       if ("family" %in% names(formals(fun)) &&
           !family_is_binomial(args$family)) {
         stop("Currently only binomial and bernoulli models are supported.",

--- a/tests/testthat/test-SurveyMap.R
+++ b/tests/testthat/test-SurveyMap.R
@@ -777,3 +777,17 @@ test_that("exact matches don't cause an error", {
   expect_silent(mapper$mapping())
 })
 
+test_that("SurveyMap$fit() errors if weights are provided",{
+  ex_map <- SurveyMap$new(samp, popn, q_age, q_pet, q_gender)
+  ex_map$mapping()
+  ex_map$tabulate()
+  expect_error(
+    ex_map$fit(
+      formula = y ~ (1|age) + (1|gender),
+      fun = lme4::lmer,
+      weights = 1
+    ),
+    "The 'weights' argument is not allowed when fitting models"
+  )
+})
+


### PR DESCRIPTION
closes #160

Throws an error if the user tries to pass a `weights` argument to the model fitting function. 